### PR TITLE
bugfix: Remove disabled action

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -21,8 +21,3 @@ jobs:
           author-name: Scalameta Bot
           repos-file: repos.md
           other-args: '--add-labels'
-      - uses: gautamkrishnar/keepalive-workflow@v2
-        if: always()
-        with:
-          committer_username: Scalameta Bot
-          committer_email: scalameta@gmail.com


### PR DESCRIPTION
```
keepalive-workflow Repository Disabled

The gautamkrishnar/keepalive-workflow repository has been temporarily disabled by GitHub due to a Terms of Service violation.

I believe this may be a mistake and have contacted GitHub Support for clarification. I’m currently awaiting their response and will share updates as soon as possible.

Update Apr 22 2025 20:47 : The GitHub team confirmed that this is a TOS violation because it promoted excessive usage by circumventing the 60‑day inactivity policy. I’ve asked whether they can restore the repository so I can gracefully remove the project after informing the users about this. Waiting for their reply on this.

```

So it seems Github is actively fighting such attempts :/ 